### PR TITLE
Update instructions to install lab extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Or if you use jupyterlab:
 
 ```bash
 pip install ipycytoscape
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension install jupyter-cytoscape@0.1.2
+jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape
 ```
 
 If you are using Jupyter Notebook 5.2 or earlier, you may also need to enable


### PR DESCRIPTION
The JupyterLab extensions can be installed using a single `jupyter labextension install` command, which will result in a single build being triggered.