### PR TITLE
Add postBuild file to enable the lab extension on Binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - ipycytoscape=0.2.1
+  - jupyterlab=2
   - matplotlib-base
   - networkx

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,2 @@
+jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape@0.2.1
+


### PR DESCRIPTION
Also bump JupyterLab to 2.x.

To try this branch on Binder:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/ipycytoscape/binder?urlpath=%2Flab)
