### PR TITLE
Update install instructions + say jupyter more + mention examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ jupyter labextension install .
 For classic notebook, you can run:
 
 ```
-jupyter nbextension install --sys-prefix --symlink --overwrite --py <your python package name>
-jupyter nbextension enable --sys-prefix --py <your python package name>
+jupyter nbextension install --sys-prefix --symlink --overwrite --py ipycytoscape
+jupyter nbextension enable --sys-prefix --py ipycytoscape
 ```
 
 Note that the `--symlink` flag doesn't work on Windows, so you will here have to run

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/Quantstack/ipycytoscape.svg?branch=master)](https://travis-ci.org/Quantstack/ipycytoscape)
 
-Python implementation of the graph visualization tool Cytoscape.
+A widget enabling interactive graph visualization with [cytoscape.js](https://js.cytoscape.org/) in JupyterLab and the Jupyter notebook.
 
-Try it out using binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/ipycytoscape/stable?filepath=examples)
+Try it out using binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/ipycytoscape/stable?filepath=examples) or install and try out the [examples](examples).
 
 ![cytoscape screencast](https://user-images.githubusercontent.com/17600982/76328068-bbbbcf00-62e2-11ea-93ed-01ba392ac50c.gif)
 

--- a/README.md
+++ b/README.md
@@ -44,28 +44,53 @@ jupyter nbextension enable --py [--sys-prefix|--user|--system] ipycytoscape
 ## For a development installation:
 **(requires npm)**
 
-```bash
-git clone https://github.com/QuantStack/ipycytoscape.git
-cd ipycytoscape
-```
-
-It's recommended to create a conda environment:
-
+While not required, we recommend creating a conda environment to work in:
 ```bash
 conda create -n ipycytoscape -c conda-forge jupyterlab nodejs
 conda activate ipycytoscape
+
+# clone repo
+git clone https://github.com/QuantStack/ipycytoscape.git
+cd ipycytoscape
+
+# Install python package for development, runs npm install and npm run build
+pip install -e .
 ```
 
-Install and enable extension for `jupyter notebook` and `jupyter lab`:
+When developing ipycytoscape, you need to manually enable the extension with the
+notebook / lab frontend. For lab, this is done by the command:
 
+```
+# install jupyterlab-manager and this extension
+jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
+jupyter labextension install .
+```
+
+For classic notebook, you can run:
+
+```
+jupyter nbextension install --sys-prefix --symlink --overwrite --py <your python package name>
+jupyter nbextension enable --sys-prefix --py <your python package name>
+```
+
+Note that the `--symlink` flag doesn't work on Windows, so you will here have to run
+the `install` command every time that you rebuild your extension. For certain installations
+you might also need another flag instead of `--sys-prefix`, but we won't cover the meaning
+of those flags here.
+
+### How to see your changes
+#### Typescript: 
+To continuously monitor the project for changes and automatically trigger a rebuild, start Jupyter in watch mode:
 ```bash
-python -m pip install -e .
-npm install && npm run build
-jupyter nbextension install --py --symlink --sys-prefix ipycytoscape
-jupyter nbextension enable ipycytoscape --py --sys-prefix
-jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape
-jupyter labextension install js
+jupyter lab --watch
 ```
+And in a separate session, begin watching the source directory for changes:
+```bash
+npm run watch
+```
+
+#### Python:
+If you make a change to the python code then you need to restart the notebook kernel to have it take effect.
 
 ## License
 


### PR DESCRIPTION
Closes: https://github.com/QuantStack/ipycytoscape/issues/49

# Changes:
**1. Initial description**
I added more mentions of jupyter and pointed out that the examples directory exists. (on github the examples link will open the appropriate folder in the github ui)

**2. Install instructions**
Previously the install instructions did not actually lead to local development install of the javascript aspects of the widget. I borrowed heavily from the install instructions in the [typescript cookiecutter](https://github.com/jupyter-widgets/widget-ts-cookiecutter) to rewrite them. 

I also added a section on how to continuously compile typescript changes and to rebuild jupyter accordingly which I based on the instructions in the jupyterlab-git README which I have found very helpful (https://github.com/jupyterlab/jupyterlab-git#install-1).
