### PR TITLE
chore: automate having mybinder files up to date

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -1,0 +1,25 @@
+# this uses https://pydoit.org/ to run tasks/chores
+# pip install doit
+# $ doit
+import pkg_resources
+from ipycytoscape._version import __version__ as version
+import re
+
+
+def task_mybinder():
+    """Make the mybinder files up to date"""
+
+    def action(targets):
+        for filename in targets:
+            with open(filename) as f:
+                content = f.read()
+            content = re.sub('cytoscape(?P<cmp>[^0-9]*)([0-9\.].*)', rf'cytoscape\g<cmp>{version}', content)
+            with open(filename, "w") as f:
+                f.write(content)
+            print(f"{filename} updated")
+
+    return {
+        'actions': [action],
+        'targets': ["environment.yml", 'postBuild'],
+        'file_dep': ['ipycytoscape/_version.py']
+        }


### PR DESCRIPTION
This automates replacing the version numbers in the mybinder files.
This uses the _version.py file as truth, maybe you also want an action in the task to update the json file and have a git hook?