### PR TITLE
Lazy loading lab, distribute more files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "cytoscape"
   ],
   "files": [
-    "lib/**/*.js",
-    "dist/*.js",
-    "css/*.css"
+    "{dist,lib}/**/*.{js,ts,map}",
+    "css/*.css",
+    "LICENSE"
   ],
   "homepage": "https://github.com/Quantstack/ipycytoscape",
   "bugs": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -33,6 +33,8 @@ function activateWidgetExtension(
   registry.registerWidget({
     name: MODULE_NAME,
     version: MODULE_VERSION,
-    exports: async () => await import(/* webpackChunkName: "jupyter-cytoscape" */ './widget'),
+
+    exports: async () =>
+      await import(/* webpackChunkName: "jupyter-cytoscape" */ './widget'),
   });
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,9 +11,7 @@ import {
 
 import {
   IJupyterWidgetRegistry
- } from '@jupyter-widgets/base';
-
-import * as widgetExports from './widget';
+} from '@jupyter-widgets/base';
 
 import {
   MODULE_NAME, MODULE_VERSION
@@ -41,6 +39,6 @@ function activateWidgetExtension(app: Application<Widget>, registry: IJupyterWid
   registry.registerWidget({
     name: MODULE_NAME,
     version: MODULE_VERSION,
-    exports: widgetExports,
+    exports: async () => await import(/* webpackChunkName: "jupyter-cytoscape" */ './widget'),
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop":true,
     "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Thanks for this publishing this repo!

This PR is just some tweaks to packaging:
- change the generated module type to be `esnext` so that it can...
- move the the loading of the widget (and its dependencies) to be lazy loaded when a widget is actually requested
  - sizes
    - in production, this is 600kb
    - in development, this is 5mb
  - seems like not too much, in the face of a 5/35mb bundle, but if every library adds another 0.5mb, end users start getting out-of-memory errors :crying_cat_face: 
- add the source maps, typings and license files to the distribution
  - for When Things Break