### PR TITLE
Convert networkx graphs + add default styling for directed graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Try it out using binder: [![Binder](https://mybinder.org/badge_logo.svg)](https:
 
 #### Supports:
 
-* Conversion from NetworkX see [example](https://github.com/QuantStack/ipycytoscape/blob/master/examples/Test%20NetworkX%20methods.ipynb)
+* Conversion from NetworkX see [example1](https://github.com/QuantStack/ipycytoscape/blob/master/examples/Test%NetworkX%20methods.ipynb)[example2](https://github.com/QuantStack/ipycytoscape/blob/master/examples/NetworkX%20Example.ipynb)
 * Conversion from Pandas DataFrame see [example](https://github.com/QuantStack/ipycytoscape/blob/master/examples/DataFrame%20interaction.ipynb)
 
 ## Installation

--- a/examples/NetworkX Example.ipynb
+++ b/examples/NetworkX Example.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipycytoscape\n",
+    "import ipywidgets as widgets\n",
+    "import networkx as nx\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Undirected graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = nx.complete_graph(5)\n",
+    "undirected = ipycytoscape.CytoscapeWidget()\n",
+    "undirected.graph.add_graph_from_networkx(G)\n",
+    "undirected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### You can also add more nodes \n",
+    "\n",
+    "The above graph should update when you run the next cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G2 = nx.Graph()\n",
+    "G2.add_node('separate node 1')\n",
+    "G2.add_node('separate node 2')\n",
+    "G2.add_edge('separate node 1', 'separate node 2')\n",
+    "undirected.graph.add_graph_from_networkx(G2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fully directed graphs\n",
+    "\n",
+    "`add_graph_from_networkx` takes an argument `directed` that if True will ensure all edges given the directed class, which will style them with an arrow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = nx.complete_graph(5)\n",
+    "directed = ipycytoscape.CytoscapeWidget()\n",
+    "directed.graph.add_graph_from_networkx(G, directed=True)\n",
+    "directed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mixed graphs\n",
+    "\n",
+    "You can also make graphs with both directed and undirected edges by adding 'directed' to the 'classes' attribute of the edge data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from random import random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = nx.complete_graph(5)\n",
+    "for s, t, data in G.edges(data=True):\n",
+    "    if random() > .5:\n",
+    "        G[s][t]['classes'] = 'directed'\n",
+    "\n",
+    "mixed = ipycytoscape.CytoscapeWidget()\n",
+    "mixed.graph.add_graph_from_networkx(G)\n",
+    "mixed"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -181,7 +181,7 @@ class Graph(Widget):
             else:
                 raise ValueError("The id doesn't exist in your graph.")
 
-    def add_graph_from_networkx(self, g):
+    def add_graph_from_networkx(self, g, directed=False):
         """
         Converts a NetworkX graph in to a Cytoscape graph.
         Parameters
@@ -190,6 +190,9 @@ class Graph(Widget):
         g: nx graph
             receives a generic NetworkX graph. more info in
             https://networkx.github.io/documentation/
+        directed: boolean
+            Whether to style the edges as directed. Equivalent to adding
+            'directed' to the 'classes' attribute of edge.data for all edges
         """
 
         cyto_attrs = ['group', 'removed', 'selected', 'selectable',
@@ -213,6 +216,8 @@ class Graph(Widget):
             edge_instance = Edge()
             set_attributes(edge_instance, data)
             edge_instance.data = {'source': source, 'target': target}
+            if directed and 'directed' not in edge_instance.classes:
+                edge_instance.classes += 'directed'
             self.edges.append(edge_instance)
 
     def add_graph_from_json(self, json_file):

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -298,22 +298,30 @@ class CytoscapeWidget(DOMWidget):
     cytoscape_layout = Dict({'name': 'cola'}).tag(sync=True)
     cytoscape_style = List([
                             {
-                            'selector': 'node',
-                            'css': {
-                                'background-color': '#11479e'
-                                }
-                            },
+                                'selector': 'node',
+                                'css': {
+                                    'background-color': '#11479e'
+                                    }
+                                },
                             {
-                            'selector': 'node:parent',
-                            'css': {
-                                'background-opacity': 0.333
-                                }
-                            },
+                                'selector': 'node:parent',
+                                'css': {
+                                    'background-opacity': 0.333
+                                    }
+                                },
                             {
                                 'selector': 'edge',
                                 'style': {
                                     'width': 4,
                                     'line-color': '#9dbaea',
+                                }
+                            },
+                            {
+                                'selector': 'edge.directed',
+                                'style': {
+                                    'curve-style': 'bezier',
+                                    'target-arrow-shape': 'triangle',
+                                    'target-arrow-color': '#9dbaea',
                                 }
                             }
                         ]).tag(sync=True)

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -191,14 +191,28 @@ class Graph(Widget):
             receives a generic NetworkX graph. more info in
             https://networkx.github.io/documentation/
         """
-        for node in g.nodes():
+
+        cyto_attrs = ['group', 'removed', 'selected', 'selectable',
+                      'locked', 'grabbed', 'grabbable', 'classes', 'position']
+
+        def set_attributes(instance, data):
+            for k, v in data.items():
+                if k in cyto_attrs:
+                    setattr(instance, k, v)
+                else:
+                    instance.data[k] = v
+
+        for node, data in g.nodes(data=True):
             node_instance = Node()
-            node_instance.data = {'id': int(node)}
+            set_attributes(node_instance, data)
+            if 'id' not in data:
+                node_instance.data['id'] = node
             self.nodes.append(node_instance)
 
-        for edge in g.edges():
+        for source, target, data in g.edges(data=True):
             edge_instance = Edge()
-            edge_instance.data = {'source': edge[0],'target': edge[1]}
+            set_attributes(edge_instance, data)
+            edge_instance.data = {'source': source, 'target': target}
             self.edges.append(edge_instance)
 
     def add_graph_from_json(self, json_file):

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -191,7 +191,8 @@ class Graph(Widget):
             receives a generic NetworkX graph. more info in
             https://networkx.github.io/documentation/
         directed: boolean
-            Whether to style the edges as directed. Equivalent to adding
+            If true all edges will be given directed as class if
+            they do not already have it. Equivalent to adding
             'directed' to the 'classes' attribute of edge.data for all edges
         """
 
@@ -220,7 +221,7 @@ class Graph(Widget):
                 edge_instance.classes += 'directed'
             self.edges.append(edge_instance)
 
-    def add_graph_from_json(self, json_file):
+    def add_graph_from_json(self, json_file, directed=False):
         """
         Converts a JSON Cytoscape graph in to a ipycytoscape graph.
         (This method only allows the conversion from a JSON that's already
@@ -229,6 +230,9 @@ class Graph(Widget):
         ----------
         self: cytoscape graph
         json_file: json file
+        directed: boolean
+            If True all edges will be given 'directed' as a class if
+            they do not already have it.
         """
         for node in json_file['nodes']:
             node_instance = Node()
@@ -239,9 +243,11 @@ class Graph(Widget):
             for edge in json_file['edges']:
                 edge_instance = Edge()
                 edge_instance.data = edge['data']
+                if directed and 'directed' not in edge_instance.classes:
+                    edge_instance.classes += 'directed'
                 self.edges.append(edge_instance)
 
-    def add_graph_from_df(self, df, groupby_cols, attribute_list=[], edges=tuple()):
+    def add_graph_from_df(self, df, groupby_cols, attribute_list=[], edges=tuple(), directed=False):
         """
         Converts any Pandas DataFrame in to a Cytoscape graph.
         Parameters
@@ -252,6 +258,9 @@ class Graph(Widget):
         attribute_list: list of strings (dataframe columns)
         edges: tuple in wich the first argument is the source edge and the
             second is the target edge
+        directed: boolean
+            If True all edges will be given 'directed' as a class if
+            they do not already have it.
         """
         grouped = df.groupby(groupby_cols)
         group_nodes = {}
@@ -279,8 +288,12 @@ class Graph(Widget):
                 graph_nodes.append(Node(data={'id': index, 'parent': parent.data['id'],
                                             'name': tip_content}))
 
+                if directed:
+                    classes = 'directed'
+                else:
+                    classes = ''
                 graph_edges.append(Edge(data={'id': index, 'source': edges[0],
-                                            'target': edges[1]}))
+                                            'target': edges[1], 'classes': classes}))
 
         # Adds group nodes and regular nodes to the graph object
         all_nodes = list(group_nodes.values()) + graph_nodes

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -215,8 +215,10 @@ class Graph(Widget):
 
         for source, target, data in g.edges(data=True):
             edge_instance = Edge()
+            edge_instance.data['source'] = source
+            edge_instance.data['target'] = target
             set_attributes(edge_instance, data)
-            edge_instance.data = {'source': source, 'target': target}
+
             if directed and 'directed' not in edge_instance.classes:
                 edge_instance.classes += 'directed'
             self.edges.append(edge_instance)

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -130,7 +130,12 @@ export class GraphModel extends WidgetModel {
       graph.push({
         group: 'nodes',
         data: node.get('data'),
+        selected: node.get('selected'),
+        selectable: node.get('selectable'),
+        locked: node.get('locked'),
+        grabbed: node.get('grabbed'),
         classes: node.get('classes'),
+        position: node.get('position'),
       });
     }
     for (let j = 0; j < this.attributes.edges.length; j++) {
@@ -138,7 +143,12 @@ export class GraphModel extends WidgetModel {
       graph.push({
         group: 'edges',
         data: edge.get('data'),
+        selected: edge.get('selected'),
+        selectable: edge.get('selectable'),
+        locked: edge.get('locked'),
+        grabbed: edge.get('grabbed'),
         classes: edge.get('classes'),
+        position: edge.get('position'),
       });
     }
 


### PR DESCRIPTION
Fixes: https://github.com/QuantStack/ipycytoscape/issues/45
Also Fixes: https://github.com/QuantStack/ipycytoscape/issues/48
Partially fixes: https://github.com/QuantStack/ipycytoscape/issues/64 (only for networkx, and only on the python side)

### Fully converting networkx
If a networkx node or edge has one of the cytoscape attributes in its data then it will be added to the `Node` or `Edge` object. I also took the approach of letting the json serialization handle the node id, this seems to work for the most common situations: node id is a number or string. It also first checks if `id` is present. If no, then it falls back on the networkx node id (i.e. `data['id'] = node`)

### Allowing for directed and mixed graphs
I added a selector `'edge.directed'` to the default style so that any edge with `'directed'` in it's `'classes'` attribute will be styled with an arrow. Each `add_graph_from_*` function also got a `directed` argument that, if True, will cause each edge that is added to be styled as a directed edge. I had to add `'curve-style': 'bezier'` to these edges to get the arrows for some reason.

### New example 
Finally I made a new NetworkX example demonstrating how to use the new directed argument or to make a mixed graph. 

From the new NetworkX example I made:
![image](https://user-images.githubusercontent.com/10111092/82165673-fd896880-9883-11ea-916f-d1ffa9308aa0.png)
![image](https://user-images.githubusercontent.com/10111092/82165683-0aa65780-9884-11ea-9641-38d28607d85a.png)
![image](https://user-images.githubusercontent.com/10111092/82165704-1abe3700-9884-11ea-8bee-d47eb8fb6e2f.png)



