### PR TITLE
Allow any attribute of data to be used for tip + deal with line breaks

### DIFF
--- a/examples/DataFrame interaction.ipynb
+++ b/examples/DataFrame interaction.ipynb
@@ -42,7 +42,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cytoscapeobj = CytoscapeWidget()"
+    "cytoscapeobj = CytoscapeWidget()\n",
+    "cytoscapeobj.set_tooltip_source('name')"
    ]
   },
   {
@@ -62,6 +63,13 @@
    "source": [
     "cytoscapeobj"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -80,7 +88,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/examples/Tip gene example.ipynb
+++ b/examples/Tip gene example.ipynb
@@ -34,6 +34,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting the tooltip text\n",
+    "\n",
+    "You can control what shows up in the tooltip when you click on a node with the `tooltip_source` attribute. By default the widget will look for `data['tooltip']` and if that exists use it as the text for the tooltip. Using the `set_tooltip_source` function you can choose to use other attributes, here we use `'name'` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cytoscapeobj.set_tooltip_source('name')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -366,6 +366,6 @@ class CytoscapeWidget(DOMWidget):
         Parameters
         ----------
         source : string
-            The key in data that will used to populate the tooltip
+            The key in data that will be used to populate the tooltip
         """
         self.tooltip_source = source

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -305,6 +305,7 @@ class CytoscapeWidget(DOMWidget):
                         ]).tag(sync=True)
     zoom = Float(2.0).tag(sync=True)
     rendered_position = Dict({'renderedPosition': { 'x': 100, 'y': 100 }}).tag(sync=True)
+    tooltip_source = Unicode('tooltip').tag(sync=True)
 
     graph = Instance(Graph, args=tuple()).tag(sync=True, **widget_serialization)
 
@@ -337,7 +338,6 @@ class CytoscapeWidget(DOMWidget):
 
         self.cytoscape_layout = dummyDict
 
-
     def get_layout(self):
         """
         Gets the layout of the current object.
@@ -346,7 +346,8 @@ class CytoscapeWidget(DOMWidget):
 
     def set_style(self, style):
         """
-        Sets the layout of the current object. Change the parameters with a dictionary.
+        Sets the layout of the current object. Change the parameters
+        with a dictionary.
         Parameters
         ----------
         stylesheet: dict
@@ -359,3 +360,12 @@ class CytoscapeWidget(DOMWidget):
         Gets the style of the current object.
         """
         return self.cytoscape_style
+
+    def set_tooltip_source(self, source):
+        """
+        Parameters
+        ----------
+        source : string
+            The key in data that will used to populate the tooltip
+        """
+        self.tooltip_source = source

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -164,6 +164,7 @@ export class CytoscapeModel extends DOMWidgetModel {
       elements: [],
       zoom: 0,
       rendered_position: {},
+      tooltip_source: '',
 
       graph: null,
     };
@@ -362,7 +363,8 @@ export class CytoscapeView extends DOMWidgetView {
         const ref = node.popperRef();
         const dummyDomEle = document.createElement('div');
 
-        if (node.data().name) {
+        const tooltip_source = this.model.get('tooltip_source');
+        if (node.data()[tooltip_source]) {
           const tip = Tippy(dummyDomEle, {
             //TODO: add a pretty tippy
             trigger: 'manual',
@@ -371,17 +373,10 @@ export class CytoscapeView extends DOMWidgetView {
             theme: 'material',
             placement: 'bottom',
             content: () => {
-              /*
-                  TODO:
-                  Currently this function is mapping to one attribute inside
-                  nodes[data], which in this case is name.
-                  The backend is using that to import various datas from
-                  DataFrames, the problem is that data will appear unformatted.
-                  Not even line breaks are working for some reason.
-                  Make the visualization better, see issue: #33
-                */
               const content = document.createElement('div');
-              content.innerHTML = node.data().name;
+              content.innerHTML = node
+                .data()
+                [tooltip_source].replace(/(?:\r\n|\r|\n)/g, '<br>');
               return content;
             },
             onCreate: (instance: Instance | undefined) => {


### PR DESCRIPTION
Fixes? https://github.com/QuantStack/ipycytoscape/issues/33

This fixes the line breaks discussed in that issue but doesn't change the text styling or background of the tip.

- replace `\n` and its ilk with `<br>` when creating the tip
- Allow the user to choose what attribute of data is used as the source of the tooltip. Defaults to `'tooltip'`

I also updated the gene example with an explanation and use this to maintain the way the dataframe example works:
![image](https://user-images.githubusercontent.com/10111092/82261864-d38c8080-992d-11ea-84f2-a4b5c96938d2.png)

![image](https://user-images.githubusercontent.com/10111092/82261843-c7a0be80-992d-11ea-9178-c9fe3c4bd592.png)
