### PR TITLE
Syncing improvements

### DIFF
--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -10,7 +10,7 @@ from spectate import mvc
 from traitlets import TraitType
 
 from ipywidgets import DOMWidget, Widget, widget_serialization
-from traitlets import Unicode, Bool, Float, Integer, Instance, Dict, List, Union
+from traitlets import Unicode, Bool, CFloat, Integer, Instance, Dict, List, Union
 from ._frontend import module_name, module_version
 
 """TODO: Remove this after this is somewhat done"""
@@ -314,8 +314,8 @@ class CytoscapeWidget(DOMWidget):
     _view_module_version = Unicode(module_version).tag(sync=True)
 
     # interaction options
-    min_zoom = Float(1e-50).tag(sync=True)
-    max_zoom = Float(1e50).tag(sync=True)
+    min_zoom = CFloat(1e-50).tag(sync=True)
+    max_zoom = CFloat(1e50).tag(sync=True)
     zooming_enabled = Bool(True).tag(sync=True)
     user_zooming_enabled = Bool(True).tag(sync=True)
     panning_enabled = Bool(True).tag(sync=True)
@@ -334,10 +334,10 @@ class CytoscapeWidget(DOMWidget):
     hide_edges_on_viewport = Bool(False).tag(sync=True)
     texture_on_viewport = Bool(False).tag(sync=True)
     motion_blur = Bool(False).tag(sync=True)
-    motion_blur_opacity = Float(0.2).tag(sync=True)
-    wheel_sensitivity = Float(1).tag(sync=True)
+    motion_blur_opacity = CFloat(0.2).tag(sync=True)
+    wheel_sensitivity = CFloat(1).tag(sync=True)
     cytoscape_layout = Dict({'name': 'cola'}).tag(sync=True)
-    pixel_ratio = Union([Unicode(), Float()], default_value='auto').tag(sync=True)
+    pixel_ratio = Union([Unicode(), CFloat()], default_value='auto').tag(sync=True)
     cytoscape_style = List([
                             {
                                 'selector': 'node',
@@ -367,7 +367,7 @@ class CytoscapeWidget(DOMWidget):
                                 }
                             }
                         ]).tag(sync=True)
-    zoom = Float(2.0).tag(sync=True)
+    zoom = CFloat(2.0).tag(sync=True)
     rendered_position = Dict({'renderedPosition': { 'x': 100, 'y': 100 }}).tag(sync=True)
     tooltip_source = Unicode('tooltip').tag(sync=True)
 

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -10,7 +10,7 @@ from spectate import mvc
 from traitlets import TraitType
 
 from ipywidgets import DOMWidget, Widget, widget_serialization
-from traitlets import Unicode, Bool, Float, Integer, Instance, Dict, List
+from traitlets import Unicode, Bool, Float, Integer, Instance, Dict, List, Union
 from ._frontend import module_name, module_version
 
 """TODO: Remove this after this is somewhat done"""
@@ -337,6 +337,7 @@ class CytoscapeWidget(DOMWidget):
     motion_blur_opacity = Float(0.2).tag(sync=True)
     wheel_sensitivity = Float(1).tag(sync=True)
     cytoscape_layout = Dict({'name': 'cola'}).tag(sync=True)
+    pixel_ratio = Union([Unicode(), Float()], default_value='auto').tag(sync=True)
     cytoscape_style = List([
                             {
                                 'selector': 'node',

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -357,6 +357,10 @@ export class CytoscapeView extends DOMWidgetView {
     this.model.on('change:cytoscape_layout', this.value_changed, this);
     this.model.on('change:cytoscape_style', this.value_changed, this);
     this.model.on('change:elements', this.value_changed, this);
+    const layout = this.model.get('layout');
+    if (layout !== null) {
+      layout.on_some_change(['width', 'height'], this._resize, this);
+    }
 
     this.displayed.then(() => {
       this.init_render();
@@ -429,6 +433,13 @@ export class CytoscapeView extends DOMWidgetView {
           tip.show();
         }
       });
+    }
+  }
+
+  private _resize() {
+    if (this.cytoscape_obj) {
+      this.cytoscape_obj.resize();
+      this.cytoscape_obj.fit();
     }
   }
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -357,6 +357,7 @@ export class CytoscapeView extends DOMWidgetView {
     this.model.on('change:cytoscape_layout', this.value_changed, this);
     this.model.on('change:cytoscape_style', this.value_changed, this);
     this.model.on('change:elements', this.value_changed, this);
+    this.model.on('change:pixel_ratio', this.value_changed, this);
     const layout = this.model.get('layout');
     if (layout !== null) {
       layout.on_some_change(['width', 'height'], this._resize, this);
@@ -398,6 +399,7 @@ export class CytoscapeView extends DOMWidgetView {
         motionBlur: this.model.get('motion_blur'),
         motionBlurOpacity: this.model.get('motion_blur_opacity'),
         wheelSensitivity: this.model.get('wheel_sensitivity'),
+        pixelRatio: this.model.get('pixel_ratio'),
         layout: this.model.get('cytoscape_layout'),
         style: this.model.get('cytoscape_style'),
         elements: this.model.get('graph').converts_dict(),


### PR DESCRIPTION
Closes: https://github.com/QuantStack/ipycytoscape/issues/83
Helps with: https://github.com/QuantStack/ipycytoscape/issues/76

- Used `CFloat` everwhere instead of `Float`
   - This is safer/better because it tries to correct non floats to floats - at least I think this is better??
- Added the `pixelRatio` option by way of traitlets union
- use the cytoscape `resize` and `fit` functions to make the graph automatically resize to fit if a user changes the layout size
**without change**
![no-resize](https://user-images.githubusercontent.com/10111092/84948690-14f18680-b0ba-11ea-8f7e-5ec6bc16a149.gif)
**with**
![with-resize](https://user-images.githubusercontent.com/10111092/84948691-1622b380-b0ba-11ea-933e-122a74f8eab7.gif)

Using `_resize` instead of `value_changed` is what I was talking about in https://github.com/QuantStack/ipycytoscape/pull/78#issuecomment-643552977

