### PR TITLE
Set attributes for JSON graphs

### DIFF
--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -205,7 +205,7 @@ class Graph(Widget):
             _set_attributes(edge_instance, data)
 
             if directed and 'directed' not in edge_instance.classes:
-                edge_instance.classes += 'directed'
+                edge_instance.classes += ' directed '
             self.edges.append(edge_instance)
 
     def add_graph_from_json(self, json_file, directed=False):
@@ -234,7 +234,7 @@ class Graph(Widget):
                 edge_instance = Edge()
                 _set_attributes(edge_instance, edge)
                 if directed and 'directed' not in edge_instance.classes:
-                    edge_instance.classes += 'directed'
+                    edge_instance.classes += ' directed '
             self.edges.extend(edge_instance)
 
     def add_graph_from_df(self, df, groupby_cols, attribute_list=[], edges=tuple(), directed=False):
@@ -279,7 +279,7 @@ class Graph(Widget):
                                             'name': tip_content}))
 
                 if directed:
-                    classes = 'directed'
+                    classes = 'directed '
                 else:
                     classes = ''
                 graph_edges.append(Edge(data={'id': index, 'source': edges[0],


### PR DESCRIPTION
Fixes: https://github.com/QuantStack/ipycytoscape/issues/98
Fixes: https://github.com/QuantStack/ipycytoscape/issues/95
Also fixes: https://github.com/QuantStack/ipycytoscape/issues/93

- Moved `_set_attributes` outside of the graph widget as it is general
- Used `_set_attributes` to ensure that all attributes get set for the `from_json` method
- Populate a separate list when creating graph elements to avoid multiple messages to the frontend.
- Added spaces around the 'directed' class in order to not break thing when there are other preexisting classes. (I still think that a list is a more robust solution here)

Fixed classes:
![image](https://user-images.githubusercontent.com/10111092/85236778-d841ca00-b3ee-11ea-84ab-160612a1723c.png)
