### PR TITLE
Track changes to Node and Edge attributes + small fix and code cleaning

### DIFF
--- a/examples/HTML interaction with graph.ipynb
+++ b/examples/HTML interaction with graph.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,16 +33,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6875d88916f94ed0a08e2ed0e7567ec9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "cytoscapeobj"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,9 +80,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "13d7f2deac5f495787281ac5cece6f34",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='red edges', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "btn = widgets.Button(description=\"red edges\", disabled=False)\n",
     "\n",
@@ -83,9 +113,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6875d88916f94ed0a08e2ed0e7567ec9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'edge.highlighted', 'css': {'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cytoscapeobj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aa1dbcbd63c049deb721384239777790",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='blue nodes', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "btn = widgets.Button(description=\"blue nodes\", disabled=False)\n",
     "\n",
@@ -98,6 +167,13 @@
     "btn.on_click(callback=btn_callback)\n",
     "display(btn)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -116,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/examples/HTML interaction with graph.ipynb
+++ b/examples/HTML interaction with graph.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipycytoscape\n",
+    "import ipywidgets as widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "with open(\"colaData.json\") as fi:\n",
+    "    json_file = json.load(fi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cytoscapeobj = ipycytoscape.CytoscapeWidget()\n",
+    "cytoscapeobj.graph.add_graph_from_json(json_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cytoscapeobj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The reason why the graph goes gray here it's because we're overwriting the style and not giving it any colors\n",
+    "#this will be done later on when we attribute the `highlighted` class to the edges and nodes on the `for`\n",
+    "\n",
+    "cytoscapeobj.set_style([{\n",
+    "  \"selector\": \"edge.highlighted\",\n",
+    "  \"css\": {\n",
+    "    \"line-color\": \"red\"\n",
+    "  }\n",
+    "},\n",
+    "{\n",
+    "  \"selector\": \"node.highlighted\",\n",
+    "  \"css\": {\n",
+    "    \"background-color\": \"blue\"\n",
+    "  },\n",
+    "}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "btn = widgets.Button(description=\"red edges\", disabled=False)\n",
+    "\n",
+    "def btn_callback(b):\n",
+    "  for edge in cytoscapeobj.graph.edges:\n",
+    "    classes = set(edge.classes.split(\" \"))\n",
+    "    classes.add(\"highlighted\")\n",
+    "    edge.classes = \" \".join(classes)\n",
+    "\n",
+    "btn.on_click(callback=btn_callback)\n",
+    "display(btn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "btn = widgets.Button(description=\"blue nodes\", disabled=False)\n",
+    "\n",
+    "def btn_callback(b):\n",
+    "  for node in cytoscapeobj.graph.nodes:\n",
+    "    classes = set(node.classes.split(\" \"))\n",
+    "    classes.add(\"highlighted\")\n",
+    "    node.classes = \" \".join(classes)\n",
+    "\n",
+    "btn.on_click(callback=btn_callback)\n",
+    "display(btn)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -134,6 +134,7 @@ class Edge(Widget):
     _model_name = Unicode('EdgeModel').tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
     _model_module_version = Unicode(module_version).tag(sync=True)
+    _view_name = Unicode('EdgeView').tag(sync=True)
     _view_module = Unicode(module_name).tag(sync=True)
     _view_module_version = Unicode(module_version).tag(sync=True)
 

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -318,7 +318,8 @@ class Graph(Widget):
                 _set_attributes(edge_instance, edge)
                 if directed and 'directed' not in edge_instance.classes:
                     edge_instance.classes += ' directed '
-            self.edges.extend(edge_instance)
+                edge_list.append(edge_instance)
+            self.edges.extend(edge_list)
 
     def add_graph_from_df(self, df, groupby_cols, attribute_list=[], edges=tuple(), directed=False):
         """

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -76,9 +76,9 @@ export class EdgeModel extends WidgetModel {
       _model_name: EdgeModel.model_name,
       _model_module: EdgeModel.model_module,
       _model_module_version: EdgeModel.model_module_version,
-      // _view_name: EdgeModel.view_name,
-      // _view_module: EdgeModel.view_module,
-      // _view_module_version: EdgeModel.view_module_version,
+      _view_name: EdgeModel.view_name,
+      _view_module: EdgeModel.view_module,
+      _view_module_version: EdgeModel.view_module_version,
 
       group: '',
       removed: false,
@@ -93,16 +93,12 @@ export class EdgeModel extends WidgetModel {
     };
   }
 
-  static serializers: ISerializers = {
-    ...WidgetModel.serializers,
-  };
-
   static model_name = 'EdgeModel';
   static model_module = MODULE_NAME;
   static model_module_version = MODULE_VERSION;
-  // static view_name = 'EdgeView';
-  // static view_module = MODULE_NAME;
-  // static view_module_version = MODULE_VERSION;
+  static view_name = 'EdgeView';
+  static view_module = MODULE_NAME;
+  static view_module_version = MODULE_VERSION;
 }
 
 export class GraphModel extends WidgetModel {
@@ -207,114 +203,47 @@ export class NodeView extends WidgetView {
     });
     this.parentModel = this.options.parentModel;
 
-    this.model.on('change:group', this.groupChanged, this);
-    this.model.on('change:removed', this.removedChanged, this);
-    this.model.on('change:selected', this.selectedChanged, this);
-    this.model.on('change:locked', this.lockedChanged, this);
-    this.model.on('change:grabbed', this.grabbedChanged, this);
-    this.model.on('change:grabbable', this.grabbableChanged, this);
-    this.model.on('change:classes', this.classesChanged, this);
-    this.model.on('change:data', this.dataChanged, this);
-    this.model.on('change:position', this.positionChanged, this);
+    this.model.on('change:group', this.valueChanged, this);
+    this.model.on('change:removed', this.valueChanged, this);
+    this.model.on('change:selected', this.valueChanged, this);
+    this.model.on('change:locked', this.valueChanged, this);
+    this.model.on('change:grabbed', this.valueChanged, this);
+    this.model.on('change:grabbable', this.valueChanged, this);
+    this.model.on('change:classes', this.valueChanged, this);
+    this.model.on('change:data', this.valueChanged, this);
+    this.model.on('change:position', this.valueChanged, this);
   }
 
-  //TODO: not sure if this is necessary to propagate the changes...
-  groupChanged() {
-    this.parentModel.set('group', this.model.get('group'));
-  }
-
-  removedChanged() {
-    this.parentModel.set('removed', this.model.get('removed'));
-  }
-
-  selectedChanged() {
-    this.parentModel.set('selected', this.model.get('selected'));
-  }
-
-  lockedChanged() {
-    this.parentModel.set('locked', this.model.get('locked'));
-  }
-
-  grabbedChanged() {
-    this.parentModel.set('grabbed', this.model.get('grabbed'));
-  }
-
-  grabbableChanged() {
-    this.parentModel.set('grabbable', this.model.get('grabbable'));
-  }
-
-  classesChanged() {
-    this.parentModel.set('classes', this.model.get('classes'));
-  }
-
-  dataChanged() {
-    this.parentModel.set('data', this.model.get('data'));
-  }
-
-  positionChanged() {
-    this.parentModel.set('position', this.model.get('position'));
+  valueChanged() {
+    this.parentModel.value_changed();
   }
 }
 
-// export
-// class EdgeView extends WidgetView {
-//   parentModel: any;
+export class EdgeView extends WidgetView {
+  parentModel: any;
 
-//   constructor(params: any) {
-//     super({
-//       model: params.model,
-//       options: params.options
-//     });
-//   this.parentModel = this.options.parentModel;
+  constructor(params: any) {
+    super({
+      model: params.model,
+      options: params.options,
+    });
+    this.parentModel = this.options.parentModel;
 
-//   this.model.on('change:group', this.groupChanged, this);
-//   this.model.on('change:removed', this.removedChanged, this);
-//   this.model.on('change:selected', this.selectedChanged, this);
-//   this.model.on('change:locked', this.lockedChanged, this);
-//   this.model.on('change:grabbed', this.grabbedChanged, this);
-//   this.model.on('change:grabbable', this.grabbableChanged, this);
-//   this.model.on('change:classes', this.classesChanged, this);
-//   this.model.on('change:data', this.dataChanged, this);
-//   this.model.on('change:position', this.positionChanged, this);
-//   }
+    this.model.on('change:group', this.valueChanged, this);
+    this.model.on('change:removed', this.valueChanged, this);
+    this.model.on('change:selected', this.valueChanged, this);
+    this.model.on('change:locked', this.valueChanged, this);
+    this.model.on('change:grabbed', this.valueChanged, this);
+    this.model.on('change:grabbable', this.valueChanged, this);
+    this.model.on('change:classes', this.valueChanged, this);
+    this.model.on('change:data', this.valueChanged, this);
+    this.model.on('change:position', this.valueChanged, this);
+  }
 
-//   //TODO: not sure if this is necessary to propagate the changes...
-//   groupChanged() {
-//     this.parentModel.set("group", this.model.get('group'));
-//   }
-
-//   removedChanged() {
-//     this.parentModel.set("removed", this.model.get('removed'));
-//   }
-
-//   selectedChanged() {
-//     this.parentModel.set("selected", this.model.get('selected'));
-//   }
-
-//   lockedChanged() {
-//     this.parentModel.set("locked", this.model.get('locked'));
-//   }
-
-//   grabbedChanged() {
-//     this.parentModel.set("grabbed", this.model.get('grabbed'));
-//   }
-
-//   grabbableChanged() {
-//     this.parentModel.set("grabbable", this.model.get('grabbable'));
-//   }
-
-//   classesChanged() {
-//     this.parentModel.set("classes", this.model.get('classes'));
-//   }
-
-//   dataChanged() {
-//     this.parentModel.set("data", this.model.get('data'));
-//   }
-
-//   positionChanged() {
-//     this.parentModel.set("position", this.model.get('position'));
-//   }
-// }
+  valueChanged() {
+    this.parentModel.value_changed();
+  }
+}
 
 export class CytoscapeView extends DOMWidgetView {
   cytoscape_obj: any;
@@ -333,20 +262,19 @@ export class CytoscapeView extends DOMWidgetView {
     );
     this.nodeViews.update(this.model.get('graph').get('nodes'));
 
-    // this.edgeViews = new widgets.ViewList(this.addEdgeModel, this.removeEdgeView, this);
-    // this.edgeViews.update(this.model.get('graph').get('edges'));
+    this.edgeViews = new widgets.ViewList(
+      this.addEdgeModel,
+      this.removeEdgeView,
+      this
+    );
+    this.edgeViews.update(this.model.get('graph').get('edges'));
 
     this.value_changed();
 
     this.model.get('graph').on('change:nodes', this.value_changed, this);
     this.model.get('graph').on('change:edges', this.value_changed, this);
-    //TODO: not sure if these are useful, the one for style is not
-    //but for layout it seems to make a difference. Need to test and
-    //remove the ones that are not and figure out why
-    // TODO 2:
-    // some of these changes do not require re-running init_render
-    // there are cytoscapejs functions that can be called to run change
-    // these options
+
+    //Python attributes that must be sync. with frontend
     this.model.on('change:min_zoom', this.value_changed, this);
     this.model.on('change:max_zoom', this.value_changed, this);
     this.model.on('change:zooming_enabled', this.value_changed, this);
@@ -368,6 +296,7 @@ export class CytoscapeView extends DOMWidgetView {
       this.listenForUserEvents,
       this
     );
+
     const layout = this.model.get('layout');
     if (layout !== null) {
       layout.on_some_change(['width', 'height'], this._resize, this);
@@ -499,7 +428,7 @@ export class CytoscapeView extends DOMWidgetView {
   addNodeModel(NodeModel: any) {
     return this.create_child_view(NodeModel, {
       cytoscapeView: this,
-      parentModel: this.model,
+      parentModel: this,
     });
   }
 
@@ -507,15 +436,14 @@ export class CytoscapeView extends DOMWidgetView {
     nodeView.remove();
   }
 
-  // addEdgeModel(EdgeModel: any) {
-  //   console.log('adding edge model')
-  //     return this.create_child_view(EdgeModel, {
-  //         cytoscapeView: this,
-  //         parentModel: this.model,
-  //     });
-  // }
+  addEdgeModel(EdgeModel: any) {
+    return this.create_child_view(EdgeModel, {
+      cytoscapeView: this,
+      parentModel: this,
+    });
+  }
 
-  // removeEdgeView(edgeView: any) {
-  //     edgeView.remove();
-  // }
+  removeEdgeView(edgeView: any) {
+    edgeView.remove();
+  }
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -209,9 +209,15 @@ export class NodeView extends WidgetView {
     this.model.on('change:locked', this.valueChanged, this);
     this.model.on('change:grabbed', this.valueChanged, this);
     this.model.on('change:grabbable', this.valueChanged, this);
-    this.model.on('change:classes', this.valueChanged, this);
+    this.model.on('change:classes', this._updateClasses, this);
     this.model.on('change:data', this.valueChanged, this);
     this.model.on('change:position', this.valueChanged, this);
+    this.cyId = this.model.get('data')['id'];
+  }
+
+  private _updateClasses() {
+    const elem = this.cytoscapeView.cytoscape_obj.getElementById(this.cyId);
+    elem.classes(this.model.get('classes'));
   }
 
   valueChanged() {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -195,6 +195,7 @@ export class CytoscapeModel extends DOMWidgetModel {
 
 export class NodeView extends WidgetView {
   cytoscapeView: any;
+  private cyId: string;
 
   constructor(params: any) {
     super({

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -194,14 +194,14 @@ export class CytoscapeModel extends DOMWidgetModel {
 }
 
 export class NodeView extends WidgetView {
-  parentModel: any;
+  cytoscapeView: any;
 
   constructor(params: any) {
     super({
       model: params.model,
       options: params.options,
     });
-    this.parentModel = this.options.parentModel;
+    this.cytoscapeView = this.options.cytoscapeView;
 
     this.model.on('change:group', this.valueChanged, this);
     this.model.on('change:removed', this.valueChanged, this);
@@ -215,19 +215,19 @@ export class NodeView extends WidgetView {
   }
 
   valueChanged() {
-    this.parentModel.value_changed();
+    this.cytoscapeView.value_changed();
   }
 }
 
 export class EdgeView extends WidgetView {
-  parentModel: any;
+  cytoscapeView: any;
 
   constructor(params: any) {
     super({
       model: params.model,
       options: params.options,
     });
-    this.parentModel = this.options.parentModel;
+    this.cytoscapeView = this.options.cytoscapeView;
 
     this.model.on('change:group', this.valueChanged, this);
     this.model.on('change:removed', this.valueChanged, this);
@@ -241,7 +241,7 @@ export class EdgeView extends WidgetView {
   }
 
   valueChanged() {
-    this.parentModel.value_changed();
+    this.cytoscapeView.value_changed();
   }
 }
 
@@ -309,7 +309,6 @@ export class CytoscapeView extends DOMWidgetView {
 
   value_changed() {
     if (this.is_rendered) {
-      console.log('value_changed');
       // Rerendering creates a new cytoscape object, so we will need to re-add
       // interaction handlers. Set `monitored` to empty to trigger this.
       this.monitored = {};
@@ -428,7 +427,6 @@ export class CytoscapeView extends DOMWidgetView {
   addNodeModel(NodeModel: any) {
     return this.create_child_view(NodeModel, {
       cytoscapeView: this,
-      parentModel: this,
     });
   }
 
@@ -439,7 +437,6 @@ export class CytoscapeView extends DOMWidgetView {
   addEdgeModel(EdgeModel: any) {
     return this.create_child_view(EdgeModel, {
       cytoscapeView: this,
-      parentModel: this,
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/QuantStack/ipycytoscape/issues/102

This PR fixes a very old issue we had with the interaction between the frontend and the Node and Edge attributes of cytoscape.
Now it's possible to do granular changes on the following attributes:

```
group
removed
selected
locked
grabbed
grabbable
classes
data
position
```
This allows us to do things like changing the color of only one node, or only one edge or a few different nodes and edges, depending on how you add classes and iterate over them. You can check the new `HTML interaction` example to see a working example, it was mainly copied on the example posted by @christiandreher, thanks for bringing it up! :)

It should be possible to generate colorful graphs! :) like this:

![image](https://user-images.githubusercontent.com/17600982/85532064-e6fecb80-b5fe-11ea-8636-9d66db6bf744.png)


This was a feature requested long ago by @pwrose, I'm sorry it took so long for me to implement it, maybe it's still useful for you!

Besides that in this PR I'm also fixing a bug we had in the `add_graph_from_json` that we missed in the last PR by @ianhi, we were forgetting to append the edges to the `edge_list` before extending it to actual `edges` object, this was the only thing I had to change: `edge_list.append(edge_instance)`.

I also cleaned the typescript a bit removing comments, prints and some unused variables after my refactoring.

This new code brings some performance issues if you use this new functionality but since it's a bit hard to resolve it, I'll leave it like it is and open an issue with some architecture ideas of how we could improve it.

Maybe @martinRenou and/or @ianhi are interested in reviewing this?
Thanks!