### PR TITLE
Coerce networkx node objects to str.

### DIFF
--- a/examples/NetworkX Example.ipynb
+++ b/examples/NetworkX Example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,9 +20,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6edb40d600de48a79abb604ae8ec8397",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "G = nx.complete_graph(5)\n",
     "undirected = ipycytoscape.CytoscapeWidget()\n",
@@ -41,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,9 +78,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9aff7dbc4e374de28c5f5f78f4ce836c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "G = nx.complete_graph(5)\n",
     "directed = ipycytoscape.CytoscapeWidget()\n",
@@ -84,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,9 +123,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5fcd69352ff347b2bfcb7ffd62a5c107",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "G = nx.complete_graph(5)\n",
     "for s, t, data in G.edges(data=True):\n",
@@ -106,13 +151,70 @@
     "mixed.graph.add_graph_from_networkx(G)\n",
     "mixed"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Custom networkx Node Objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cba2590dca7c4ed3b07d83fe71823452",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "class Node:\n",
+    "    def __init__(self, name):\n",
+    "        self.name = name\n",
+    "        \n",
+    "    def __str__(self):\n",
+    "        return \"Node: \" + str(self.name)\n",
+    "\n",
+    "n1 = Node(\"node 1\")\n",
+    "n2 = Node(\"node 2\")\n",
+    "        \n",
+    "G = nx.Graph()\n",
+    "\n",
+    "G.add_node(n1)\n",
+    "G.add_node(n2)\n",
+    "\n",
+    "G.add_edge(n1, n2)\n",
+    "\n",
+    "w = ipycytoscape.CytoscapeWidget()\n",
+    "w.graph.add_graph_from_networkx(G)\n",
+    "w"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.2 64-bit",
    "language": "python",
-   "name": "python3"
+   "name": "python38264bit634cbc6ffe284c77a8a5106bedf46d77"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/NetworkX Example.ipynb
+++ b/examples/NetworkX Example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,24 +20,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "120a13c03d1546f39b69f14aac7151e0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "G = nx.complete_graph(5)\n",
     "undirected = ipycytoscape.CytoscapeWidget()\n",
@@ -56,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,24 +63,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1fe947fdafb84545a2923cbbd3e467cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "G = nx.complete_graph(5)\n",
     "directed = ipycytoscape.CytoscapeWidget()\n",
@@ -114,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,24 +93,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f50e9e317e27488db8a9be2afd1eae86",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "G = nx.complete_graph(5)\n",
     "for s, t, data in G.edges(data=True):\n",
@@ -156,29 +111,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Custom networkx Node Objects"
+    "# Custom networkx Node Objects\n",
+    "\n",
+    "The most common choices for Nodes in networkx are numbers or strings as shown above. A node can also be any hashable object (except None) which work as well."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21a9d117b9944f8baad2fd68f75d64cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node', 'css': {'background-c…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "class Node:\n",
     "    def __init__(self, name):\n",
@@ -203,25 +145,19 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 8,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d84b57a3ce8643d6a0c9db5f252ff801",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node.class1', 'css': {'backg…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "source": [
+    "# Custom networkx Node Objects that inherit from ipycytoscape.Node\n",
+    "\n",
+    "While custom networkx Node objects work, they do not allow as much control over formatting as you may need. The easiest way to achieve customization with custom Node objects is to subclass ipycytoscape.Node as show below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "class CustomNode(ipycytoscape.Node):\n",
     "    def __init__(self, name, classes=''):\n",
@@ -256,13 +192,6 @@
     "                        }])\n",
     "custom_inherited"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/NetworkX Example.ipynb
+++ b/examples/NetworkX Example.ipynb
@@ -24,9 +24,35 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "0\n",
+      "2\n",
+      "0\n",
+      "3\n",
+      "0\n",
+      "4\n",
+      "1\n",
+      "2\n",
+      "1\n",
+      "3\n",
+      "1\n",
+      "4\n",
+      "2\n",
+      "3\n",
+      "2\n",
+      "4\n",
+      "3\n",
+      "4\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6edb40d600de48a79abb604ae8ec8397",
+       "model_id": "ec932158f1d54fa4856175577a9ec060",
        "version_major": 2,
        "version_minor": 0
       },
@@ -84,7 +110,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9aff7dbc4e374de28c5f5f78f4ce836c",
+       "model_id": "64ca801aeb92406994fa4bcf1c3a5438",
        "version_major": 2,
        "version_minor": 0
       },
@@ -129,7 +155,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5fcd69352ff347b2bfcb7ffd62a5c107",
+       "model_id": "088c04699f9b468ebb98acf03df6d2d4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -161,13 +187,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node: node 1\n",
+      "Node: node 2\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cba2590dca7c4ed3b07d83fe71823452",
+       "model_id": "4aeb697d46dc45c9ad93bf0bd9cbb1f6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -200,6 +234,69 @@
     "w = ipycytoscape.CytoscapeWidget()\n",
     "w.graph.add_graph_from_networkx(G)\n",
     "w"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CustomNode(classes='class1', data={'id': 'node 1'}, position={})\n",
+      "CustomNode(classes='class2', data={'id': 'node 2'}, position={})\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8653c7b58da1441ca61b527f5ceb8b4b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'cola'}, cytoscape_style=[{'selector': 'node.class1', 'css': {'backg…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "class CustomNode(ipycytoscape.Node):\n",
+    "    def __init__(self, name, classes=''):\n",
+    "        super().__init__()\n",
+    "        self.data['id'] = name\n",
+    "        self.classes = classes\n",
+    "\n",
+    "n1 = CustomNode(\"node 1\", classes='class1')\n",
+    "n2 = CustomNode(\"node 2\", classes='class2')\n",
+    "        \n",
+    "G = nx.Graph()\n",
+    "\n",
+    "G.add_node(n1)\n",
+    "G.add_node(n2)\n",
+    "\n",
+    "G.add_edge(n1, n2)\n",
+    "\n",
+    "custom_inherited = ipycytoscape.CytoscapeWidget()\n",
+    "custom_inherited.graph.add_graph_from_networkx(G)\n",
+    "custom_inherited.set_style([\n",
+    "                        {\n",
+    "                            'selector': 'node.class1',\n",
+    "                            'css': {\n",
+    "                                'background-color': 'red'\n",
+    "                            }\n",
+    "                        },\n",
+    "                        {\n",
+    "                            'selector': 'node.class2',\n",
+    "                            'css': {\n",
+    "                                'background-color': 'green'\n",
+    "                            }\n",
+    "                        }])\n",
+    "custom_inherited"
    ]
   },
   {

--- a/examples/NetworkX Example.ipynb
+++ b/examples/NetworkX Example.ipynb
@@ -24,35 +24,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "1\n",
-      "0\n",
-      "2\n",
-      "0\n",
-      "3\n",
-      "0\n",
-      "4\n",
-      "1\n",
-      "2\n",
-      "1\n",
-      "3\n",
-      "1\n",
-      "4\n",
-      "2\n",
-      "3\n",
-      "2\n",
-      "4\n",
-      "3\n",
-      "4\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ec932158f1d54fa4856175577a9ec060",
+       "model_id": "120a13c03d1546f39b69f14aac7151e0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -110,7 +84,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "64ca801aeb92406994fa4bcf1c3a5438",
+       "model_id": "1fe947fdafb84545a2923cbbd3e467cb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -155,7 +129,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "088c04699f9b468ebb98acf03df6d2d4",
+       "model_id": "f50e9e317e27488db8a9be2afd1eae86",
        "version_major": 2,
        "version_minor": 0
       },
@@ -187,21 +161,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Node: node 1\n",
-      "Node: node 2\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4aeb697d46dc45c9ad93bf0bd9cbb1f6",
+       "model_id": "21a9d117b9944f8baad2fd68f75d64cb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -238,21 +204,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CustomNode(classes='class1', data={'id': 'node 1'}, position={})\n",
-      "CustomNode(classes='class2', data={'id': 'node 2'}, position={})\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8653c7b58da1441ca61b527f5ceb8b4b",
+       "model_id": "d84b57a3ce8643d6a0c9db5f252ff801",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/NetworkX Example.ipynb
+++ b/examples/NetworkX Example.ipynb
@@ -196,9 +196,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.2 64-bit",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python38264bit634cbc6ffe284c77a8a5106bedf46d77"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -385,21 +385,18 @@ class Graph(Widget):
 
         edge_list = list()
         for source, target, data in g.edges(data=True):
-            #print(source)
-            #print(target)
             edge_instance = Edge()
 
-            # if issubclass(type(source), Node):
-            #     edge_instance.data['source'] = source
-            # else:    
-            #     edge_instance.data['source'] = str(source)
-            # if issubclass(type(target), Node):
-            #     edge_instance.data['target'] = target
-            # else:    
-            #     edge_instance.data['target'] = str(target)
+            if issubclass(type(source), Node):
+                edge_instance.data['source'] = source.data['id']
+            else:
+                edge_instance.data['source'] = str(source)
             
-            edge_instance.data['source'] = str(source)
-            edge_instance.data['target'] = str(target)
+            if issubclass(type(target), Node):
+                edge_instance.data['target'] = target.data['id']
+            else:
+                edge_instance.data['target'] = str(target)
+
             _set_attributes(edge_instance, data)
 
             if directed and 'directed' not in edge_instance.classes:

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -373,16 +373,31 @@ class Graph(Widget):
         """
         node_list = list()
         for node, data in g.nodes(data=True):
-            node_instance = Node()
-            _set_attributes(node_instance, data)
-            if 'id' not in data:
-                node_instance.data['id'] = str(node)
+            if issubclass(type(node), Node):
+                node_instance = node
+            else:
+                node_instance = Node()
+                _set_attributes(node_instance, data)
+                if 'id' not in data:
+                    node_instance.data['id'] = str(node)
             node_list.append(node_instance)
         self.add_nodes(node_list)
 
         edge_list = list()
         for source, target, data in g.edges(data=True):
+            #print(source)
+            #print(target)
             edge_instance = Edge()
+
+            # if issubclass(type(source), Node):
+            #     edge_instance.data['source'] = source
+            # else:    
+            #     edge_instance.data['source'] = str(source)
+            # if issubclass(type(target), Node):
+            #     edge_instance.data['target'] = target
+            # else:    
+            #     edge_instance.data['target'] = str(target)
+            
             edge_instance.data['source'] = str(source)
             edge_instance.data['target'] = str(target)
             _set_attributes(edge_instance, data)

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -376,15 +376,15 @@ class Graph(Widget):
             node_instance = Node()
             _set_attributes(node_instance, data)
             if 'id' not in data:
-                node_instance.data['id'] = node
+                node_instance.data['id'] = str(node)
             node_list.append(node_instance)
         self.add_nodes(node_list)
 
         edge_list = list()
         for source, target, data in g.edges(data=True):
             edge_instance = Edge()
-            edge_instance.data['source'] = source
-            edge_instance.data['target'] = target
+            edge_instance.data['source'] = str(source)
+            edge_instance.data['target'] = str(target)
             _set_attributes(edge_instance, data)
 
             if directed and 'directed' not in edge_instance.classes:


### PR DESCRIPTION
Here's an alternative approach to handling custom networkx node objects. It requires the networkx node to implement __str__, but doesn't require the user's networkx code to depend on ipycytoscape. 