### PR TITLE
Remove pip because it's for the older version

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,6 @@
 type: sphinx
 python:
   version: 3.5
-  pip_install: true
   extra_requirements:
     - examples
     - docs


### PR DESCRIPTION
Remove pip because it's for the older version of read the docs.
I'm trying to build everything with conda here, should be possible.