### PR TITLE
update rtd environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,4 +10,6 @@ dependencies:
  - jupyter-sphinx>=0.3.1
  - sphinx-copybutton
  - nbsphinx
- - nbsphinx-link
+ - pip
+ - pip:
+    - nbsphinx_link


### PR DESCRIPTION
conda wasn't picking up the nbsphinx requirement correctly, causing the rtd build to fail.

I tested the change locally with:
```
conda env create --name latest --file docs/environment.yml
```
and the environment was successfully created
