### PR TITLE
Fix link to the pandas example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Try it out using binder: [![Binder](https://mybinder.org/badge_logo.svg)](https:
 #### Supports:
 
 * Conversion from NetworkX see [example1](https://github.com/QuantStack/ipycytoscape/blob/master/examples/Test%20NetworkX%20methods.ipynb), [example2](https://github.com/QuantStack/ipycytoscape/blob/master/examples/NetworkX%20Example.ipynb)
-* Conversion from Pandas DataFrame see [example](https://github.com/QuantStack/ipycytoscape/blob/master/examples/DataFrame%20interaction.ipynb)
+* Conversion from Pandas DataFrame see [example](https://github.com/QuantStack/ipycytoscape/blob/master/examples/pandas.ipynb)
 
 ## Installation
 


### PR DESCRIPTION
See the rename in https://github.com/QuantStack/ipycytoscape/commit/bae68218d5447a23485998958985619a4e3bce78#diff-870faec7f00b589156bad51f44320f92d8f73d48f3b5d2ca100093564e717f17