### PR TITLE
Allow to resize the widget

### DIFF
--- a/css/widget.css
+++ b/css/widget.css
@@ -2,4 +2,6 @@
   background-color: white;
   height: 400px;
   width: 100%;
+  resize: both;
+  border: 1px dashed #ccc;
 }

--- a/css/widget.css
+++ b/css/widget.css
@@ -3,5 +3,8 @@
   height: 400px;
   width: 100%;
   resize: both;
-  border: 1px dashed #ccc;
+}
+
+.custom-widget:hover {
+    border: 1px dashed #ccc;
 }


### PR DESCRIPTION
Two-line implementation for #76. The border is not required but beneficial to locate the corner as the resize symbol is not always consistently shown/easily visible across browsers and environments.

![ipycytoscape](https://user-images.githubusercontent.com/5832902/99903848-ff166c00-2cbe-11eb-8919-8966d16382d8.gif)
