### PR TITLE
correct mistakes in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,29 @@ pip install ipycytoscape
 
 #### For jupyterlab users:
 
-There is an aditional step if you're using JupyterLab:
+If you are using JupyterLab 1.x or 2.x then you will also need to install `nodejs` and the `jupyterlab-manager` extension. You can do this like so:
 
 ```bash
-jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape
+# installing nodejs
+conda install -c conda-forge nodejs
+
+
+# install jupyterlab-manager extension
+jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
+
+# if you have previously installed the manager you still to run jupyter lab build
+jupyter lab build
 ```
 
-And make sure you have an updated version of `nodejs` (>13) and Jupyter Lab in your environment.
+### For Jupyter Notebook 5.2 and earlier
 
-If you are using Jupyter Notebook 5.2 or earlier, you may also need to enable
-the nbextension:
+You may also need to manually enable the nbextension:
 ```bash
 jupyter nbextension enable --py [--sys-prefix|--user|--system] ipycytoscape
 ```
 
 ## For a development installation:
+
 **(requires npm)**
 
 While not required, we recommend creating a conda environment to work in:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@ or with conda/`mamba <https://github.com/TheSnakePit/mamba>`_::
     # or with mamba
     mamba install -c conda-forge ipycytoscape
 
+If you are using JupyterLab you will also need to follow the instructions in :ref:`jlab-install-instructions`.
 
 Simple Example
 --------------

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -16,19 +16,22 @@ or with conda/`mamba <https://github.com/TheSnakePit/mamba>`_::
     mamba install -c conda-forge ipycytoscape
 
 
-JupyterLab
-----------
+.. _jlab-install-instructions:
+
+JupyterLab Installation
+-----------------------
+
 In order to install the JupyterLab extension jupyter-cytoscape, you will first need to install nodejs,
 you can install it with conda by doing
 
-.. code-block::bash
+.. code-block:: bash
     
     conda install -c conda-forge nodejs
 
 The ``jupyer-cytoscape`` labextension should have been automatically installed for you when you installed
 the Python package, but you still need to install the JupyterLab widget manager:
 
-.. code-block::bash
+.. code-block:: bash
 
     jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
 


### PR DESCRIPTION
closes: https://github.com/QuantStack/ipycytoscape/issues/178


- corrects the issue where some code blocks weren't rendering 
- removed manual installation of `jupyter-cytoscape`
- clarified jlab extra steps in the readme
- link to jlab install instructions from index.html