### PR TITLE
Upgrade spectate to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup_args = dict(
     include_package_data=True,
     install_requires=[
         "ipywidgets>=7.6.0",
-        "spectate>=0.4.1",
+        "spectate>=1.0.0",
         "networkx",
     ],
     extras_require={


### PR DESCRIPTION
A [1.0 release](https://github.com/rmorshea/spectate/releases/tag/1.0.0) of spectate was recently published.

It includes some minor breaking changes, but they should not impact the usages here.