### PR TITLE
Remove jupyter-cytoscape version pin in postBuild

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,1 @@
-jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape@0.2.3
+jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape


### PR DESCRIPTION
This is the PR to resolve issue #234 . It simply removes the version pin from jupyter-cytoscape in `postBuild`.