### PR TITLE
Create new logger instead of reusing root logger

### DIFF
--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -28,8 +28,7 @@ import networkx as nx
 """TODO: Remove this after this is somewhat done"""
 import logging
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "MONITORED_USER_TYPES",


### PR DESCRIPTION
The current behaviour sets the log level of the root python logger to DEBUG which effects any other package also using this logger.

This change creates a new logger and leaves the log level at the default