### PR TITLE
Use py2neo as an extra dep.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,4 +63,4 @@ jobs:
 
     - name: Run Tests
       shell: bash -l {0}
-      run: pytest . --color=yes
+      run: pytest . --color=yes --ignore=examples/Neo4j_Example.ipynb

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Try it out using binder: [![Binder](https://mybinder.org/badge_logo.svg)](https:
 
 * Conversion from NetworkX see [example1](https://github.com/QuantStack/ipycytoscape/blob/master/examples/Test%20NetworkX%20methods.ipynb), [example2](https://github.com/QuantStack/ipycytoscape/blob/master/examples/NetworkX%20Example.ipynb)
 * Conversion from Pandas DataFrame see [example](https://github.com/QuantStack/ipycytoscape/blob/master/examples/pandas.ipynb)
+* Conversion from neo4j see [example](https://github.com/QuantStack/ipycytoscape/blob/master/examples/Neo4j_Example.ipynb)
+    - Currently there's no package of `py2neo` available that's compatible with `ipycytoscape`. As a provisory solution to this problem you can use the package offered by `pypi` and install it with the following line: `pip install -e ".[neo4j]"`
 
 ## Installation
 

--- a/ipycytoscape/cytoscape.py
+++ b/ipycytoscape/cytoscape.py
@@ -182,7 +182,7 @@ class Element(Widget):
 
 
 class Edge(Element):
-    """ Edge Widget """
+    """Edge Widget"""
 
     _model_name = Unicode("EdgeModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
@@ -198,7 +198,7 @@ class Edge(Element):
 
 
 class Node(Element):
-    """ Node Widget """
+    """Node Widget"""
 
     _model_name = Unicode("NodeModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
@@ -226,7 +226,7 @@ def _set_attributes(instance, data):
 
 
 class Graph(Widget):
-    """ Graph Widget """
+    """Graph Widget"""
 
     _model_name = Unicode("GraphModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)
@@ -739,7 +739,7 @@ class Graph(Widget):
 
 
 class CytoscapeWidget(DOMWidget):
-    """ Implements the main Cytoscape Widget """
+    """Implements the main Cytoscape Widget"""
 
     _model_name = Unicode("CytoscapeModel").tag(sync=True)
     _model_module = Unicode(module_name).tag(sync=True)

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup_args = dict(
         "neo4j": [
             "py2neo",
             "neotime",
-        ]
+        ],
     },
     entry_points={},
 )

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,6 @@ setup_args = dict(
         "ipywidgets>=7.6.0",
         "spectate>=1.0.0",
         "networkx",
-        "py2neo",
-        "neotime",
     ],
     extras_require={
         "test": ["pytest>4.6", "pytest-cov", "nbval", "pandas"],
@@ -115,6 +113,10 @@ setup_args = dict(
             "networkx",
             "pandas",
         ],
+        "neo4j": [
+            "py2neo",
+            "neotime",
+        ]
     },
     entry_points={},
 )


### PR DESCRIPTION
Currently the `py2neo` conda package is unmaintained and causing issues. This is a solution using `pypi`.
We should release a new version of ipycytoscape to fix it after this is merged.

I also want to fix the `neo4j` problem in the tests, apparently my fix in the `pytest.ini` is not working anymore?