### PR TITLE
fix quoting in test setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you make a change to the python code then you need to restart the notebook ke
 Install necessary dependencies with pip:
 
 ```
-pip install -e .[test]
+pip install -e ".[test]"
 ```
 
 Or with mamba:


### PR DESCRIPTION
The value used with the `-e` option to `pip install` is `.[test]`. The `[` character has [special meaning](https://tldp.org/LDP/abs/html/special-chars.html#LEFTBRACKET) in many popular unix shells, so must be quoted (or escaped) to get the literal character needed for `pip install` to interpret the value inside the square brackets as a local directory path.

A demonstration using `zsh`:

```
% pip install -e .[test]
zsh: no matches found: .[test]
```

Quoting `.[test]` yields the expected result:

```
% pip install -e ".[test]"
Looking in indexes: ...
```

It seems the pypa documentation has the same problem - see [`pip install` example #7](https://pip.pypa.io/en/stable/cli/pip_install/#example) . Those examples are all prefixed with `python -m pip`, however the same shell quoting rules still apply. I'll file a similar PR over there.